### PR TITLE
environment.ymlにipykernelを追加する

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: mlnote
 
 dependencies:
   - ipython
+  - ipykernel
   - python
   - numpy
   - matplotlib


### PR DESCRIPTION
素晴らしい教材を公開頂きありがとうございます。`environment.yml`に[`ipykernel`](https://github.com/ipython/ipykernel)を追加する修正を行いましたのでご確認・反映頂ければ幸いです。

### 背景
Jupyter Labの環境で機械学習帳のNotebookを実行する時、`environment.yml`で構築した`mlnote`の環境を実行カーネルとして選択する必要があります。

![image](https://user-images.githubusercontent.com/544269/186323796-5a0ff431-602a-40fe-9742-edef545bc044.png)

構築した環境を選択可能なカーネルとして登録するには[`ipython kernel install`](https://ipython.readthedocs.io/en/stable/install/kernel_install.html)のコマンド実行が必要です。このコマンドを実行するには`ipykernel`をインストールする必要があります。現在の`environment.yml`には`ipykernel`が含まれていないため、`conda activate mlnote`⇒`conda install ipykernel`⇒`ipython kernel install`、という3ステップの手順が必要で手間がかかります。

あらかじめ`environment.yml`に`ipykernel`を含めることで、Notebook実行までの手間を減らすことができます。[`ipykernel`は`ipython`オフィシャルのプロジェクト](https://github.com/ipython/ipykernel)でありメンテナンスが行われていること、ファイルサイズはバージョンによりますが[95kb~180kb](https://anaconda.org/anaconda/ipykernel)とそれほど重たいライブラリでないことから、既存の環境に与える影響は少ないと思います。もしご懸念点があればコメントで頂ければ幸いです。
